### PR TITLE
Naprawa ArrayIndexOutOfBounds

### DIFF
--- a/src/main/java/dev/jakubk15/casedropcore/cmds/BanCommand.java
+++ b/src/main/java/dev/jakubk15/casedropcore/cmds/BanCommand.java
@@ -12,21 +12,21 @@ public class BanCommand implements CommandExecutor {
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
 			if (sender.hasPermission("essentials.ban")) {
-				if (args[0].length() >= 1) {
+				if (args.length() > 0) {
 					final Player target = Bukkit.getPlayerExact(args[0]);
 					assert target != null;
-					if (args[1].length() >= 1) {
+					//if (args.length() > 0) {
 						target.banPlayer(ChatColorUtil.fixColor("&cZostałeś zbanowany!\n\nPrzez administratora: " + sender.getName() + "\n\n&cPowód: " + args[1]));
 						sender.sendMessage(ChatColorUtil.fixColor("&3Zbanowano gracza " + target.getName() + "\n&3Powód: " + args[1]));
-					} else {
-						target.banPlayer(ChatColorUtil.fixColor("&cZostałeś zbanowany!\n\nPrzez administratora: " + sender.getName()));
-						sender.sendMessage(ChatColorUtil.fixColor("&3Zbanowano gracza " + target.getName()));
+					//} else {
+						//target.banPlayer(ChatColorUtil.fixColor("&cZostałeś zbanowany!\n\nPrzez administratora: " + sender.getName()));
+						//sender.sendMessage(ChatColorUtil.fixColor("&3Zbanowano gracza " + target.getName()));
 					}
 				} else {
 					sender.sendMessage(ChatColorUtil.fixColor("&cPodaj nick gracza!"));
 				}
 			} else {
-				sender.sendMessage(ChatColorUtil.fixColor("&cBrak uprawnien!"));
+				sender.sendMessage(ChatColorUtil.fixColor("&cBrak uprawnień!"));
 			}
 
 	return false;


### PR DESCRIPTION
Okej, a więc jest to spowodowane przez to, że zakładasz przy użyciu args[1], że jest pierwszy argument, co nie zawsze jest prawdą oraz ogólnie to nie ma sensu (to przez to, że sprawdzasz ilość argumentów gdy oznaczasz w indeksie (args[1]) argument). Zamiast tego trzeba użyć args.length, które sprawdzi dokładną ilość ogólnie. Dodatkowo używasz dwóch tych samych warunków w linii 18 oraz 15 co nie ma sensu, bo jeśli jeden będzie prawdą, to drugi też będzie musiał być. Zakomentowałem te części kodu. Podsumowując nie zakładaj że String array zawiera jakikolwiek index, bo komendy można próbować uruchomić bez argumentów tak jak to uznajesz w else tego wymagania. Dodatkowo lepiej jest wymagać więcej niż 0 zamiast 1 albo więcej niż 1.